### PR TITLE
add 'doseq' to urlencode to handle Unicode better

### DIFF
--- a/documentcloud/__init__.py
+++ b/documentcloud/__init__.py
@@ -91,7 +91,7 @@ class BaseDocumentCloudClient(object):
             params += "".join(['&document_ids[]=%s' % id for id in document_ids])
         else:
             # Otherwise, we can just use the vanilla urllib prep method
-            params = urllib.urlencode(params)
+            params = urllib.urlencode(params,doseq=True)
         # Make the request
         content = self._make_request(
             self.BASE_URI + method,


### PR DESCRIPTION
Docs with non-ascii characters in the title run into ascii-assumptions in the base implementation of urllib.urlencode

passing doseq=True causes urlencode to use a more unicode-savvy handling, independent of the "sequence" part that the kwarg name implies.

It seems like I may still have had a ’ character munged, but at least my document.put() didn't crap out completely.
