### PR TITLE
Add `force_ocr` parameter for uploads

### DIFF
--- a/docs/documents.rst
+++ b/docs/documents.rst
@@ -81,7 +81,7 @@ Editing
 Uploading
 ---------
 
-.. function:: client.documents.upload(pdf, title=None, source=None, description=None, related_article=None, published_url=None, access='private', project=None, data=None, secure=False)
+.. function:: client.documents.upload(pdf, title=None, source=None, description=None, related_article=None, published_url=None, access='private', project=None, data=None, secure=False, force_ocr=False)
 
    Upload a PDF to DocumentCloud. You must be authorized to do this. Returns the object representing the new record you've created. You can submit either a file path or a file object.
 
@@ -96,7 +96,7 @@ Uploading
 
         >>> client.documents.upload("http://ord.legistar.com/Chicago/attachments/e3a0cbcb-044d-4ec3-9848-23c5692b1943.pdf")
 
-.. function:: client.documents.upload_directory(pdf, source=None, description=None, related_article=None, published_url=None, access='private', project=None, data=None, secure=False)
+.. function:: client.documents.upload_directory(pdf, source=None, description=None, related_article=None, published_url=None, access='private', project=None, data=None, secure=False, force_ocr=False)
 
    Searches through the provided path and attempts to upload all the PDFs it can find. Metadata provided to the other keyword arguments will be recorded for all uploads. Returns a list of document objects that are created. Be warned, this will upload any documents in directories inside the path you specify.
 

--- a/documentcloud/__init__.py
+++ b/documentcloud/__init__.py
@@ -277,7 +277,7 @@ class DocumentClient(BaseDocumentCloudClient):
     def upload(
         self, pdf, title=None, source=None, description=None,
         related_article=None, published_url=None, access='private',
-        project=None, data=None, secure=False
+        project=None, data=None, secure=False, force_ocr=False
     ):
         """
         Upload a PDF or other image file to DocumentCloud.
@@ -350,6 +350,8 @@ and try again.")
                 params['data[%s]' % key] = value
         if secure:
             params['secure'] = 'true'
+        if force_ocr:
+            params['force_ocr'] = 'true'
         # Make the request
         response = self._make_request(
             self.BASE_URI + 'upload.json',
@@ -362,7 +364,7 @@ and try again.")
     def upload_directory(
         self, path, source=None, description=None,
         related_article=None, published_url=None, access='private',
-        project=None, data=None, secure=False
+        project=None, data=None, secure=False, force_ocr=False
     ):
         """
         Uploads all the PDFs in the provided directory.
@@ -389,7 +391,8 @@ and try again.")
             obj = self.upload(
                 pdf_path, source=source, description=description,
                 related_article=related_article, published_url=published_url,
-                access=access, project=project, data=data, secure=secure
+                access=access, project=project, data=data, secure=secure,
+                force_ocr=force_ocr
             )
             obj_list.append(obj)
         # Pass back the list of documents


### PR DESCRIPTION
The DocumentCloud API now lets you specify upon upload that a document should be OCR'd even if it has text in it. The new parameter, `force_ocr`, is `False` by default. This PR adds the parameter in (I believe) all the places needed to include it in the library.

We've added the parameter to our API docs as well: https://www.documentcloud.org/help/api